### PR TITLE
Introduce `<sha512-hash>` tag compatibility in root password object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2open",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/mappings/opnsense.interface.ts
+++ b/src/app/mappings/opnsense.interface.ts
@@ -153,6 +153,7 @@ export interface User {
   authorizedkeys?: string;
   ipsecpsk?: string;
   'bcrypt-hash'?: string;
+  'sha512-hash'?: string;
 }
 
 export interface Configapply {

--- a/src/app/mappings/pfsense-complex.interface.ts
+++ b/src/app/mappings/pfsense-complex.interface.ts
@@ -1051,6 +1051,7 @@ export interface User {
   authorizedkeys?: string;
   ipsecpsk?: string;
   'bcrypt-hash'?: string;
+  'sha512-hash'?: string;
 }
 
 export interface Group {

--- a/src/app/services/converter.service.ts
+++ b/src/app/services/converter.service.ts
@@ -132,7 +132,7 @@ export class ConverterService {
         ...pfSystem.user
       }
       
-      // Map bcrypt-hash or md5-hash to password
+      // Map bcrypt-hash, md5-hash, sha512-hash tags to password tag
       if (pfSystem.user?.['bcrypt-hash']) { 
         system.user.password = pfSystem.user['bcrypt-hash'];
         delete system.user['bcrypt-hash'];
@@ -141,6 +141,10 @@ export class ConverterService {
       if (pfSystem.user?.['md5-hash']) {
         system.user.password = pfSystem.user['md5-hash'];
         delete system.user['md5-hash'];
+      }
+      if (pfSystem.user?.['sha512-hash']) {
+        system.user.password = pfSystem.user['sha512-hash'];
+        delete system.user['sha512-hash'];
       }
       
       // dedupe pfSense.system.user


### PR DESCRIPTION
User login creds support the following password hashing algorithms:
- `bcrypt-hash` (default)
- `sha512-hash` (optional)
- `md5-hash` (legacy)

`sha512-hash` was missing, and this PR introduces this.

Relevant references:
- https://redmine.pfsense.org/issues/12855
- https://redmine.pfsense.org/issues/6332
- https://github.com/pfsense/FreeBSD-ports/blob/22705d90d9b8164fa968f25a042839329daa868b/sysutils/pfSense-pkg-System_Patches/files/usr/local/pkg/patches/8ddf2b5a999772754080825f07acf9b6326f1f04.patch#L10C49-L11C1

Relevant issues:
#7 #9